### PR TITLE
Change how summary value is stored

### DIFF
--- a/minchin/pelican/plugins/summary/summary.py
+++ b/minchin/pelican/plugins/summary/summary.py
@@ -85,7 +85,7 @@ def extract_summary(instance):
     summary = re.sub(r"</div>", "", summary)
 
     instance._content = content
-    instance._summary = summary
+    instance.metadata["summary"] = summary
     instance.has_summary = True
 
 


### PR DESCRIPTION
This wasn't working for me, and I think it's because Pelican made a
change to how summaries are stored. It used to be in self._summary, but
now it's treated as a regular piece of metadata: https://github.com/getpelican/pelican/blob/master/pelican/contents.py#L399

Before this change, I was generating the correct summary, (in
self._summary), but Pelican was not picking it up, using the truncated
article content instead.