### PR TITLE
Use instance.content instead of instance._content

### DIFF
--- a/minchin/pelican/plugins/summary/summary.py
+++ b/minchin/pelican/plugins/summary/summary.py
@@ -78,7 +78,7 @@ def extract_summary(instance):
     use_first_paragraph = instance.settings["SUMMARY_USE_FIRST_PARAGRAPH"]
     remove_markers = True
 
-    content = instance._content
+    content = instance.content
     begin_summary = -1
     end_summary = -1
     if begin_marker:


### PR DESCRIPTION
Using raw instance._content to generate summary can be problematic, paths inside elements are not resolved.
Examples:
* `<img>` tag: there is `<img src="{static}images/example.png">` instead of `<img src="/theme/images/example.png">`
* `<a>` tag: there is `<a href="{filename}../../pages/example.md">LINK</a>` instead of `<a href="pages/example.html">`

`instance.content` is a public method which internally calls functions which resolve paths and because it is decorated with `@property` it can be used as object's attribute.